### PR TITLE
Added ability for default branch name to vary

### DIFF
--- a/files/workflows/git_rules.yml
+++ b/files/workflows/git_rules.yml
@@ -2,7 +2,7 @@ name: Enforce Git Rules
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ $default-branch ]
     types: [ opened, synchronize, reopened, edited ]
 
 jobs:
@@ -15,8 +15,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Is Rebased on master?
+    - name: Is Rebased on the default branch?
       uses: cyberark/enforce-rebase@v2
+      with:
+        default-branch: $default-branch
 
   commit_style:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?
Some of the newer repositories will have a default branch name of `main`. This PR lets the `update-workflows` script check for the default branch name and pass it to the workflow files on creation.

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation
