### PR TITLE
Revert "Added ability for default branch name to vary"

### DIFF
--- a/files/workflows/git_rules.yml
+++ b/files/workflows/git_rules.yml
@@ -2,7 +2,7 @@ name: Enforce Git Rules
 
 on:
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
     types: [ opened, synchronize, reopened, edited ]
 
 jobs:
@@ -15,10 +15,8 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Is Rebased on the default branch?
+    - name: Is Rebased on master?
       uses: cyberark/enforce-rebase@v2
-      with:
-        default-branch: $default-branch
 
   commit_style:
     runs-on: ubuntu-latest

--- a/files/workflows/git_rules.yml
+++ b/files/workflows/git_rules.yml
@@ -2,7 +2,7 @@ name: Enforce Git Rules
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, main ]
     types: [ opened, synchronize, reopened, edited ]
 
 jobs:


### PR DESCRIPTION
Reverts cyberark/conjur-project-config#8

The variable I thought could solve this issue turned out to only be available in org templates for workflows and it not usable in workflow files themselves.